### PR TITLE
Introduce the startsWith method.

### DIFF
--- a/src/LumenForceHttps/Http/Middleware/ForceHttps.php
+++ b/src/LumenForceHttps/Http/Middleware/ForceHttps.php
@@ -23,13 +23,33 @@ class ForceHttps
             $https = $request->server("HTTPS");
             if(empty($https) || strtolower($https) == "off") {
                 // take SSL termination behind a proxy into account
-                if(!starts_with($url, 'https:')) {
+                if(!$this->startsWith($url, 'https:')) {
                     // replace the protocol and then return a redirect
                     return redirect(str_replace("http:", "https:", $url));
                 }
             }
         }
-        
+
         return $next($request);
+    }
+
+    /**
+     * Determine if a given string starts with a given substring.
+     * Taken from Laravel source
+     * https://github.com/laravel/framework/blob/a81f23d0ccd2fefa7fa9b79649ab23811631d9bf/src/Illuminate/Support/Str.php#L466
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    private function startsWith($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Since Laravel 5.8 removed the helper methods for strings and arrays which this package relied on, a simple fix is to include the startsWith that Laravel uses natively.

Fixes #1 